### PR TITLE
add zipping feature

### DIFF
--- a/inftools/misc/data_helper.py
+++ b/inftools/misc/data_helper.py
@@ -30,13 +30,13 @@ def data_reader(inp):
             # skip if no weights
             if set(f0l) == set(w0l) == set(("----",)):
             	continue
-            
+
             # store only the weights based on col
             for col, (f0, w0) in enumerate(zip(f0l, w0l)):
             	if '----' in (f0, w0):
             		continue
             	path["cols"][col] = [f0, w0]
-            
+
             # append to paths list
             paths.append(path)
         return paths

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.10,<3.13"
+python = ">=3.10,<3.14"
 numpy = "^1.26.0"
 matplotlib = "^3.7.2"
 tomli = "^2.0.1"

--- a/test/test_combine_data/test_combine_data.py
+++ b/test/test_combine_data/test_combine_data.py
@@ -1,6 +1,6 @@
 """Test methods for combine_data."""
 import os
-from distutils.dir_util import copy_tree
+import shutil
 from pathlib import PosixPath
 
 import numpy as np
@@ -18,7 +18,7 @@ def test_infinit_1(tmp_path: PosixPath) -> None:
     folder.mkdir()
     basepath = PosixPath(__file__).parent
     data_dir = (basepath / "data").resolve()
-    copy_tree(str(data_dir), str(folder))
+    shutil.copytree(str(data_dir), str(folder),dirs_exist_ok=True)
     os.chdir(folder)
 
     tomls=["sim1.toml", "sim2.toml", "sim3.toml"]
@@ -26,7 +26,6 @@ def test_infinit_1(tmp_path: PosixPath) -> None:
         tomls=tomls,
         datas=["sim1.txt.gz", "sim2.txt.gz", "sim3.txt.gz"],
         skip=100,
-        scramble=True,
         out="combo"
     )
 


### PR DESCRIPTION
Initial iteration of `inft combine_data` gave too low error estimates due to the `scramble` feature, which is now removed. 

It was initially introduced to prevent certain ensembles to have pcross = 0 for many steps. However, it not needed as now the data from the individual simulations are written to `combo.txt` in a "zipping" fashion. This should work for an arbitrary number of data files to be combined together. Consequently, the error estimates from block error estimates becomes more reliable.

As explained by https://github.com/infretis/inftools/pull/10#issuecomment-2627645615

