### PR TITLE
Trajtxt converter for trjcat when delete_old = true

### DIFF
--- a/inftools/misc/infinit_helper.py
+++ b/inftools/misc/infinit_helper.py
@@ -391,15 +391,23 @@ def smoothen_pcross(x, p):
     return x_out, 10**np.mean(p_out, axis=0)
 
 def estimate_interface_positions(x, p, pL):
-    """Place new interfaces on Pcross such that the local crossing is pL."""
+    """Place new interfaces based on Pcross.
+
+    The interfaces are placed *evenly* such that the local crossing probability
+    is at *least* pL, meaning it is a bit higher than pL most of the time.
+    """
     i = 0
     interfaces = [0]
-    while True:
-        idx = np.where(p/p[i] > pL)[0]
+    n_intf = int(np.log(p[-1])/np.log(pL)) + 1
+    pL_new = p[-1]**(1/n_intf)
+    for intf in range(n_intf):
+        idx = np.where(p/p[i] >= pL_new)[0]
         if len(idx) == len(p):
             break
         i = idx[-1]
-        # when we drop more than pL**2
+        if p[-1]/p[i] > pL_new:
+            break
+        # when we drop more than pL**2 (but not more than pL**3)
         if i in interfaces:
             i = i+1
         interfaces.append(i)

--- a/inftools/tistools/concatenate.py
+++ b/inftools/tistools/concatenate.py
@@ -1,25 +1,49 @@
 from typing import Annotated
+
 import typer
 
+
 def trjcat(
-    out: Annotated[str, typer.Option("-out", help="output trajectory name, format")],
-    traj: Annotated[str, typer.Option("-traj", help="path to the traj.txt file")],
-    selection: Annotated[str, typer.Option("-selection", help="atom selection to write to output")]="all",
-    engine: Annotated[str, typer.Option("-engine", help="what engine to use for concatenation")]="mda",
-    traj_format: Annotated[str, typer.Option("-format", help = "trajectory format, can be inferred")] = None,
-    topology: Annotated[str, typer.Option("-topology", help = "a structure file with atom info")] = None,
-    centersel: Annotated[str, typer.Option("-centersel", help="center this atom selction in the middle of the box")] = "",
-        ):
-    "Concatenate the trajectories from an infretis simulation to a single file."
-    import numpy as np
+    out: Annotated[
+        str, typer.Option("-out", help="output trajectory name, format")
+    ],
+    traj: Annotated[
+        str, typer.Option("-traj", help="path to the traj.txt file")
+    ],
+    selection: Annotated[
+        str,
+        typer.Option("-selection", help="atom selection to write to output"),
+    ] = "all",
+    engine: Annotated[
+        str,
+        typer.Option("-engine", help="what engine to use for concatenation"),
+    ] = "mda",
+    traj_format: Annotated[
+        str, typer.Option("-format", help="trajectory format, can be inferred")
+    ] = None,
+    topology: Annotated[
+        str, typer.Option("-topology", help="a structure file with atom info")
+    ] = None,
+    centersel: Annotated[
+        str,
+        typer.Option(
+            "-centersel",
+            help="center this atom selction in the middle of the box",
+        ),
+    ] = "",
+):
+    """
+    Concatenate the trajectories from an infretis simulation to a single file.
+    """
     import pathlib
-    import os
+
+    import numpy as np
+
     if engine == "mda":
         import MDAnalysis as mda
         from MDAnalysis import transformations as trans
     elif engine == "ase":
         from ase.io.trajectory import Trajectory
-        from ase.io import write
 
     traj = pathlib.Path(traj)
     out = pathlib.Path(out)
@@ -32,10 +56,10 @@ def trjcat(
         if not topology.exists():
             raise FileNotFoundError(f"No such file {topology}")
 
-
-
     traj_dir = traj.parents[0]
-    traj_file_arr, index_arr = np.loadtxt(str(traj),usecols=[1,2],comments="#",dtype=str,unpack=True)
+    traj_file_arr, index_arr = np.loadtxt(
+        str(traj), usecols=[1, 2], comments="#", dtype=str, unpack=True
+    )
     index_arr = index_arr.astype(int)
 
     # trajectory transformations
@@ -47,36 +71,44 @@ def trjcat(
     for traj_file in np.unique(traj_file_arr):
         traj_fpath = traj_dir / "accepted" / traj_file
         if not traj_fpath.exists():
-            raise FileNotFoundError(
-                    f"\n No such file {traj_fpath.resolve()}")
+            raise FileNotFoundError(f"\n No such file {traj_fpath.resolve()}")
         if engine == "mda":
             if topology is not None:
-                u = mda.Universe(topology, str(traj_fpath), format = traj_format)
+                u = mda.Universe(
+                    topology,
+                    str(traj_fpath),
+                    format=traj_format,
+                    refresh_offsets=True,
+                )
             else:
-                u = mda.Universe(str(traj_fpath), format = traj_format)
+                u = mda.Universe(
+                    str(traj_fpath), format=traj_format, refresh_offsets=True
+                )
             U[traj_file] = u
             if centersel:
                 tmp_sel = u.select_atoms(centersel)
-                workflow = [trans.center_in_box(tmp_sel),trans.wrap(u.atoms)]
+                workflow = [trans.center_in_box(tmp_sel), trans.wrap(u.atoms)]
                 u.trajectory.add_transformations(*workflow)
             n_atoms = u.select_atoms(selection).n_atoms
         elif engine == "ase":
             if selection != "all":
-                raise NotImplementedError("Only selection all is implemented for ase egnine.")
+                raise NotImplementedError(
+                    "Only selection all is implemented for ase egnine."
+                )
             U[traj_file] = Trajectory(str(traj_fpath))
             n_atoms = U[traj_file][0].positions.shape[0]
 
     # write the concatenated trajectory
     if engine == "mda":
-        with mda.Writer(out, n_atoms) as wfile:
-            for traj_file, index in zip(traj_file_arr,index_arr):
+        with mda.Writer(str(out), n_atoms) as wfile:
+            for traj_file, index in zip(traj_file_arr, index_arr):
                 u = U[traj_file]
                 ag = u.select_atoms(selection)
                 u.trajectory[index]
                 wfile.write(ag.atoms)
 
     elif engine == "ase":
-        out = Trajectory(out, "w")
+        out = Trajectory(str(out), "w")
         for traj_file, index in zip(traj_file_arr, index_arr):
             # traj object
             u = U[traj_file]

--- a/inftools/tistools/get_interfaces.py
+++ b/inftools/tistools/get_interfaces.py
@@ -1,14 +1,26 @@
 from typing import Annotated
+
 import typer
+
 
 def estimate_interfaces2(
     i: Annotated[str, typer.Option("-i", help="The Pcross.txt file")],
-    num: Annotated[int, typer.Option("-num", help="Number of interfaces")] = None,
-    ploc: Annotated[float, typer.Option("-ploc", help="Place interfaces to match ploc")] = None,
-    i0: Annotated[float, typer.Option("-i0", help="Position of the first interface")] = None,
-    iN: Annotated[float, typer.Option("-iN", help="Position of the last interface")] = None,
-    plot: Annotated[bool, typer.Option("-plot", help="Time from nskip")] = False,
-    ):
+    num: Annotated[
+        int, typer.Option("-num", help="Number of interfaces")
+    ] = None,
+    ploc: Annotated[
+        float, typer.Option("-ploc", help="Place interfaces to match ploc")
+    ] = None,
+    i0: Annotated[
+        float, typer.Option("-i0", help="Position of the first interface")
+    ] = None,
+    iN: Annotated[
+        float, typer.Option("-iN", help="Position of the last interface")
+    ] = None,
+    plot: Annotated[
+        bool, typer.Option("-plot", help="Time from nskip")
+    ] = False,
+):
     """
     Estimate the interface positions from Pcross.txt by linearizing the curve.
 
@@ -18,15 +30,18 @@ def estimate_interfaces2(
 
     """
     import numpy as np
+
     from inftools.misc.infinit_helper import (
+        estimate_interface_positions,
         smoothen_pcross,
-        estimate_interface_positions)
+    )
+
     if plot:
         import matplotlib.pyplot as plt
 
     x = np.loadtxt(i)
-    x0 = x[:,0]
-    p0 = x[:,1]
+    x0 = x[:, 0]
+    p0 = x[:, 1]
 
     # trim endpoints if i0 or iN given
     iN = x0[-1] if iN is None else iN
@@ -35,7 +50,7 @@ def estimate_interfaces2(
     first_idx = np.where(x0 >= i0)[0][0]
     x = x0[first_idx:last_idx]
     p = p0[first_idx:last_idx]
-    p = p/p[0]
+    p = p / p[0]
 
     # linearalize the curve
     x, p = smoothen_pcross(x, p)
@@ -55,12 +70,14 @@ def estimate_interfaces2(
     print(f"[INFO] There are now {len(interfaces)} interfaces.")
     print(f"[INFO] Calculated local crossing probability = {ploc}")
 
-    print("interfaces = [", ", ".join([f"{itf:.6f}" for itf in interfaces]) + "]")
+    print(
+        "interfaces = [", ", ".join([f"{itf:.6f}" for itf in interfaces]) + "]"
+    )
 
     if plot:
         f, a = plt.subplots(figsize=(8, 4))
-        a.plot(x0, p0, markersize=3, label = f"raw Pcross")
-        a.plot(x, p, label = "processed Pcross")
+        a.plot(x0, p0, markersize=3, label="raw Pcross")
+        a.plot(x, p, label="processed Pcross")
         for inter in interfaces:
             a.axvline(inter, c="k", lw=1)
         a.set(yscale="log")
@@ -68,16 +85,20 @@ def estimate_interfaces2(
         plt.show()
 
 
-
 def estimate_interfaces(
     i: Annotated[str, typer.Option("-i", help="The Pcross.txt file")],
     num: Annotated[int, typer.Option("-num", help="Number of interfaces")],
     order: Annotated[int, typer.Option("-order", help="Polynomial order")],
-    i0: Annotated[float, typer.Option("-i0", help="Position of the first interface")] = None,
-    iN: Annotated[float, typer.Option("-iN", help="Position of the last interface")] = None,
-    plot: Annotated[bool, typer.Option("-plot", help="Time from nskip")] = False,
-
-    ):
+    i0: Annotated[
+        float, typer.Option("-i0", help="Position of the first interface")
+    ] = None,
+    iN: Annotated[
+        float, typer.Option("-iN", help="Position of the last interface")
+    ] = None,
+    plot: Annotated[
+        bool, typer.Option("-plot", help="Time from nskip")
+    ] = False,
+):
     """
     Estimate interfaces from Pcross.txt
 
@@ -95,6 +116,7 @@ def estimate_interfaces(
     import matplotlib.pyplot as plt
     import numpy as np
     from scipy.optimize import curve_fit, minimize
+
     x = np.loadtxt(i)
 
     if i0 is None:
@@ -107,13 +129,19 @@ def estimate_interfaces(
     else:
         iN = float(iN)
     N = num  # number of interfaces
-    alpha = 0  # hyperparameter to penalize positive derivative of pcross, e.g. 50
+    alpha = (
+        0  # hyperparameter to penalize positive derivative of pcross, e.g. 50
+    )
 
     last_idx = np.where(x[:, 0] <= iN)[0][-1]
     first_idx = np.where(x[:, 0] >= i0)[0][0]
 
-    y_fit = np.log(x[first_idx:last_idx, 1]) - np.log(x[last_idx, 1])  # y[-1]=0
-    x_fit = x[first_idx:last_idx, 0] / (x[last_idx, 0] - x[first_idx, 0])  # x_fit in range (0,1)
+    y_fit = np.log(x[first_idx:last_idx, 1]) - np.log(
+        x[last_idx, 1]
+    )  # y[-1]=0
+    x_fit = x[first_idx:last_idx, 0] / (
+        x[last_idx, 0] - x[first_idx, 0]
+    )  # x_fit in range (0,1)
     shift = x_fit[0]
     x_fit -= shift
 
@@ -147,13 +175,11 @@ def estimate_interfaces(
             y += -pi * x + pi * x ** (order + 2)
         return y
 
-
     def dy_dp(x, *p, f0=f0):
         dy = np.zeros((x.shape[0], len(p)))  # dyi_dp0, dyi_dp1, ..., dyi_dpN
         for order, pi in enumerate(p):
             dy[:, order] = -x + x ** (order + 2)
         return dy
-
 
     def dy_dx(x, *p, f0=f0):
         dy = np.zeros(x.shape[0])  # dyi_dxi
@@ -161,7 +187,6 @@ def estimate_interfaces(
         for order, pi in enumerate(p):
             dy += -pi + (order + 2) * pi * x ** (order + 1)
         return dy
-
 
     def of(p, x_fit, y_fit, f0, alpha):
         y = fnc(x_fit, *p, f0=f0)
@@ -173,7 +198,9 @@ def estimate_interfaces(
     popt, pcov = curve_fit(fnc, x_fit, y_fit, p0=np.ones(order))
 
     # actual optimization with penalizing derivatives
-    res = minimize(of, popt, args=(x_fit, y_fit, f0, alpha), method="Nelder-mead")
+    res = minimize(
+        of, popt, args=(x_fit, y_fit, f0, alpha), method="Nelder-mead"
+    )
 
     x_eval = np.linspace(0, 1, 10000)
     y_eval = fnc(x_eval, *res.x)
@@ -185,7 +212,7 @@ def estimate_interfaces(
     # divide by y_plot[0] here in case intf0 is not equal to default
     # then shift back for plotting later
     y0 = y_plot[0]
-    y_plot = y_plot/y0
+    y_plot = y_plot / y0
     pcross = y_plot[-1]  # total crossing probability
 
     pt = np.exp(np.log(pcross) / (N - 1))  # local crossing probability
@@ -202,12 +229,15 @@ def estimate_interfaces(
     interfaces.append(iN)  # add last interface
     id_interfaces.append(len(x_plot) - 1)
     interfaces = np.round(np.array(interfaces), 9)
-    print("interfaces = [", ", ".join([f"{itf:.04f}" for itf in interfaces]) + "]")
+    print(
+        "interfaces = [",
+        ", ".join([f"{itf:.04f}" for itf in interfaces]) + "]",
+    )
 
     if plot:
         f, a = plt.subplots(figsize=(8, 4))
         a.plot(x[:, 0], x[:, 1], marker="o", markersize=3)
-        a.plot(x_plot, y_plot*y0)
+        a.plot(x_plot, y_plot * y0)
         for inter in interfaces:
             a.axvline(inter, c="k", lw=1)
         a.set(yscale="log")

--- a/inftools/tistools/get_interfaces.py
+++ b/inftools/tistools/get_interfaces.py
@@ -12,6 +12,10 @@ def estimate_interfaces2(
     """
     Estimate the interface positions from Pcross.txt by linearizing the curve.
 
+    TODO:
+        * how to handle large drops in the curve? e.g. more than pL?
+        * when we have little data, the curve will be very blocky
+
     """
     import numpy as np
     from inftools.misc.infinit_helper import (
@@ -38,17 +42,18 @@ def estimate_interfaces2(
     if ploc is not None and num is None:
         interfaces = estimate_interface_positions(x, p, ploc)
         interfaces = list(interfaces) + [iN]
-        print(f"[INFO] Added {len(interfaces)} interfaces")
 
     elif num is not None and ploc is None:
-        ploc = np.exp(np.log(p[-1]) / (num - 1))  # local crossing probability
-        print(f"[INFO] ploc = {ploc}")
+        ploc = np.exp(np.log(p[-1]) / (num - 1)) - 1e-6
         interfaces = estimate_interface_positions(x, p, ploc)
         interfaces = list(interfaces) + [iN]
-        print(f"[INFO] Added {len(interfaces)} interfaces")
 
     else:
-        raise ValueError("Cant have both -num and -ploc set!")
+        raise ValueError("Cant have both (or none) of -num and -ploc set!")
+
+    ploc = np.exp(np.log(p[-1]) / (len(interfaces) - 1))
+    print(f"[INFO] There are now {len(interfaces)} interfaces.")
+    print(f"[INFO] Calculated local crossing probability = {ploc}")
 
     print("interfaces = [", ", ".join([f"{itf:.6f}" for itf in interfaces]) + "]")
 

--- a/inftools/tistools/trajtxt_conv.py
+++ b/inftools/tistools/trajtxt_conv.py
@@ -1,0 +1,47 @@
+import argparse
+from typing import Annotated
+import typer
+
+def trajtxt_conv(
+    i: Annotated[str, typer.Option("-i")],
+    o: Annotated[str, typer.Option("-o")],
+    r: Annotated[int, typer.Option("-r", help="Subcycle ratio, subcycle xtc /subsycle trr")],
+    ):
+    """inft trjcat cannot be directly used when xtc is kept
+    while delete_old=true during a gromacs infretis sim.
+
+    Here we provide a quick traj.txt converter, that also consders
+    if xtc frames are saved more frequently."""
+
+    import numpy as np
+
+    # Assert and data
+    assert r >= 1
+    data = np.loadtxt(i, dtype="str")
+    data_out = []
+    files = []
+
+    # First get unique path files
+    for file in data[:, 1]:
+        if file not in files:
+            files.append(file)
+
+    # iterate over files
+    for file in files:
+
+        # get first, last and direction of frames in file
+        file_idx_s = int(data[data[:, 1] == file][0][2])
+        file_idx_e = int(data[data[:, 1] == file][-1][2])
+        it = int(data[data[:, 1] == file][0][-1])
+
+        # fill new data list
+        for idx in np.arange(file_idx_s*r, file_idx_e*r + it, it):
+            data_out.append([file.replace(".trr", ".xtc"), idx, it])
+
+    with open(o, "w") as write:
+        write.write("# comment\n")
+        write.write("# comment\n")
+        for idx, line in enumerate(data_out):
+            write.write(f"{idx:10.0f}    {line[0]}{line[1]:12.0f}{line[2]:7.0f}\n")
+
+    print(f"trajtxt_conv Done! with file {o}")


### PR DESCRIPTION
For gromacs simulations when delete_old = true, `inft trjcat` cannot be directly used when merging `*xtc` trajectories that utilize a traj.txt file that mentioned the deleted paths with `*trr`. This function `inft trajtxt_conv` solves this problem.