### PR TITLE
infinit lamres update

### DIFF
--- a/inftools/tistools/get_interfaces.py
+++ b/inftools/tistools/get_interfaces.py
@@ -44,16 +44,20 @@ def estimate_interfaces2(
     p0 = x[:, 1]
 
     # trim endpoints if i0 or iN given
-    iN = x0[-1] if iN is None else iN
-    i0 = x0[0] if i0 is None else i0
-    last_idx = np.where(x0 <= iN)[0][-1]
-    first_idx = np.where(x0 >= i0)[0][0]
+    last_idx = np.where(x0 <= iN)[0][-1] if iN is not None else len(x0)
+    first_idx = np.where(x0 >= i0)[0][0] if i0 is not None else 0
+    if iN is None:
+        iN = x0[-1]
+    if i0 is None:
+        i0 = x[0]
+
     x = x0[first_idx:last_idx]
     p = p0[first_idx:last_idx]
     p = p / p[0]
 
     # linearalize the curve
     x, p = smoothen_pcross(x, p)
+
     if ploc is not None and num is None:
         interfaces = estimate_interface_positions(x, p, ploc)
         interfaces = list(interfaces) + [iN]

--- a/inftools/tistools/initial_paths.py
+++ b/inftools/tistools/initial_paths.py
@@ -209,6 +209,7 @@ def infinit(
         log.log("Generating zero paths ...")
         init_conf = pl.Path(iset["initial_conf"]).resolve()
         max_op = generate_zero_paths(str(init_conf), toml = toml)
+        iset["max_op"] = max_op
         log.log(f"Done with zero paths! Max op: {max_op}\n")
         iset["cstep"] = 0
         # for placing interfaces if we start with more than 1 worker
@@ -216,10 +217,13 @@ def infinit(
         d_lambda = max_op - intf[0]
         nworkers = config["runner"]["workers"]
         lamres0 = 0.5*(d_lambda)/nworkers
-        if iset["lamres"] > lamres0:
-            print(f"Lamres too large. Setting lamres to {lamres0}.")
-            iset["lamres"] = lamres0
-            iset["max_op"] = max_op
+        # just divide by 2 until lamres checks out, then each intf remains
+        #on the bin positions
+        if nworkers>1:
+            while iset["lamres"]> lamres0:
+                iset["lamres"]/=2
+        if lamres0 != iset["lamres"]:
+            print(f"Lamres too large. Setting lamres to {iset['lamres']}.")
 
         # new interfaces to use for first infretis sim
         intf = [intf[0]] + [intf[0]+2*lamres0*(i+1) for i in range(nworkers-1)] + [intf[1]]


### PR DESCRIPTION
When generating initial paths and the new lamres was too large to fit (n_worker-1) interfaces above `interfaces[0]` and below `max_op`, we changed the lamres in a way that didn't leave the interfaces commensurate with lamres. This causes subsequent updates of the interfaces to also change the values of the first and last interfaces. Its fixed now by dividing by 2 until the lamres is small enough, such that its commensurate with the interfaces at all times.