### PR TITLE
add error msg when n_workers is too large wrt step_per_iter

### DIFF
--- a/inftools/misc/infinit_helper.py
+++ b/inftools/misc/infinit_helper.py
@@ -45,6 +45,10 @@ def set_default_infinit(config):
 
     config["infinit"]["cstep"] = cstep
     assert cstep < len(steps_per_iter), "Nothing to do"
+    if not np.all(np.array(steps_per_iter[max(cstep,0):])
+            >= config["runner"]["workers"]):
+        raise ValueError("The number of infretis steps in steps_per_iter"
+                " has to be larger or equal to the number of workers!")
     assert config["output"]["delete_old"] == False
     assert config["output"].get("delete_old_all", False) == False
     # update check here based on maximum op value


### PR DESCRIPTION
add error message on startup when steps_per_iter contains elements that are smaller than n_workers