### PR TITLE
add separate skip

### DIFF
--- a/inftools/tistools/combine_results.py
+++ b/inftools/tistools/combine_results.py
@@ -10,7 +10,7 @@ from inftools.misc.data_helper import data_reader
 
 def combine_data(tomls: Annotated[list[str], typer.Option("-tomls", help="tomls for all simulations")],
                  datas: Annotated[list[str], typer.Option("-datas", help="data files for all simulations")],
-                 skip: Annotated[int, typer.Option("-skip", help="skip initial lines for all simulations")] = 100,
+                 skip: Annotated[list[int], typer.Option("-skip", help="skip initial lines for simulations.")] = [100],
                  out: Annotated[str, typer.Option("-out", help="name for output .txt/toml file.")] = "combo"
 ):
     """Combine different infretis simulations.
@@ -24,13 +24,17 @@ def combine_data(tomls: Annotated[list[str], typer.Option("-tomls", help="tomls 
 
     -tomls sim1 -tomls sim2 -datas data1 -datas data2.
 
-    # NB: If output data is not scrambled, then one
-    column will remain as "----" state for one whole sim.
-    On the other side, in this implementation all data must
-    then be stored in ram.
+    -skip can be either one value, or specific skip value
+    must be specified for each simulation data.
     """
     # do some initial checks
     assert len(set(tomls)) == len(tomls) == len(set(datas)) == len(datas)
+
+    # check that len(skip) is either 1 (so same skip for all),
+    # or 1 for each sim
+    if len(set(tomls)) > 1 and len(skip) == 1:
+        skip = skip*len(set(tomls))
+    assert len(skip) in (1, len(set(tomls)))
 
     # initialize some variables
     sims = {}
@@ -73,7 +77,7 @@ def combine_data(tomls: Annotated[list[str], typer.Option("-tomls", help="tomls 
         col_dic = {i: j for i, j in zip(cols, recol)}
 
         for line_num, path in enumerate(sims[idx]["paths"]):
-            if line_num < skip:
+            if line_num < skip[idx]:
                 continue
             frac, weig = [], []
 

--- a/inftools/tistools/combine_results.py
+++ b/inftools/tistools/combine_results.py
@@ -32,9 +32,9 @@ def combine_data(tomls: Annotated[list[str], typer.Option("-tomls", help="tomls 
 
     # check that len(skip) is either 1 (so same skip for all),
     # or 1 for each sim
+    assert len(skip) in (1, len(set(tomls)))
     if len(set(tomls)) > 1 and len(skip) == 1:
         skip = skip*len(set(tomls))
-    assert len(skip) in (1, len(set(tomls)))
 
     # initialize some variables
     sims = {}

--- a/test/test_combine_data/test_combine_data.py
+++ b/test/test_combine_data/test_combine_data.py
@@ -25,7 +25,7 @@ def test_infinit_1(tmp_path: PosixPath) -> None:
     combine_data(
         tomls=tomls,
         datas=["sim1.txt.gz", "sim2.txt.gz", "sim3.txt.gz"],
-        skip=100,
+        skip=[100],
         out="combo"
     )
 


### PR DESCRIPTION
In case when combining data from different simulations of different lengths, one may want to skip a separate amount, so in `inft combine_data` it will now be possible to add separate skip commands, e.g. 

```
inft combine_data \
        -tomls run_1/infretis.toml \
        -tomls run_2/infretis.toml \
        -tomls run_3/infretis.toml \
        -datas run_1/infretis_data.txt \
        -datas run_2/infretis_data.txt \
        -datas run_3/infretis_data.txt \
        -skip 1000 \
        -skip 2000 \
        -skip 3000
```