### PR TITLE
fix max_op infinit

### DIFF
--- a/inftools/tistools/initial_paths.py
+++ b/inftools/tistools/initial_paths.py
@@ -125,7 +125,6 @@ def generate_zero_paths(
     # make load directories
     pathsf = [path0, path1]
     pathsr = [path0r, path1r]
-    max_op = -np.inf
     for i in range(2):
         dirname = load_dir / str(i)
         accepted = dirname / "accepted"
@@ -137,9 +136,9 @@ def generate_zero_paths(
         path = paste_paths(pathsr[i], pathsf[i])
         # save order paramter
         order = np.array([pp.order for pp in path.phasepoints])
-        max_order = np.max(order[:,0])
-        if max_order > max_op:
-            max_op = max_order
+        # return max op of [0+] path
+        if i == 1:
+            max_op = np.max(order[:,0])
         order = np.hstack((np.arange(len(order)).reshape(-1,1), np.array(order)))
         fmt = ["%d"] + ["%12.6f" for i in range(order.shape[1]-1)]
         np.savetxt(str(orderfile), order, fmt=fmt)

--- a/inftools/tistools/path_weigths.py
+++ b/inftools/tistools/path_weigths.py
@@ -1,0 +1,67 @@
+import typer
+from typing import Annotated
+
+def get_path_weights(
+        toml: Annotated[str, typer.Option("-toml", help = "The .toml file")] = "infretis.toml",
+        data: Annotated[str, typer.Option("-data", help = "The infretis_data.txt file")] = "infretis_data.txt",
+        out: Annotated[str, typer.Option("-out", help = "Output .txt of the path weights")] = "path_weights.txt",
+        nskip: Annotated[int, typer.Option("-nskip", help = "Skip the first nskip entries of the infretis_data.txt file")] = 0
+        ):
+    """Calculate the unbiased weight for each path in the plus ensembles.
+
+    Can be used to calculate observables as <O> = sum(wi*Oi).
+    """
+    import numpy as np
+    import tomli
+    import os
+
+    if os.path.exists(out):
+        raise ValueError(f"Out file {out} exists!")
+
+    # load toml and infretis_data
+    with open(toml, "rb") as rfile:
+        toml = tomli.load(rfile)
+    interfaces = toml["simulation"]["interfaces"]
+    data = np.loadtxt(data, dtype=str)
+
+    # drop nskip
+    data = data[nskip:]
+    # we only need non-zero paths
+    non_zero_paths = (data[:,3]=="----")
+    data[data=="----"] = "0.0"
+    D = {}
+
+    D["pnr"] = data[non_zero_paths,0:1].astype(int)
+    D["len"] = data[non_zero_paths,1:2].astype(int)
+    D["maxop"] = data[non_zero_paths,2:3].astype(float)
+    D["path_f"] = data[non_zero_paths,4:3+len(interfaces)].astype(float)
+    D["path_w"] = data[non_zero_paths,4+len(interfaces):3+2*len(interfaces)].astype(float)
+
+    w = D["path_f"]/D["path_w"]
+    w[np.isnan(w)]=0
+
+    ploc_unscaled = np.zeros(len(interfaces))
+    ploc_wham = np.zeros_like(ploc_unscaled)
+    ploc_unscaled[0] = 1.0
+    ploc_wham[0] = 1.0
+    for i,intf_p1 in enumerate(interfaces[1:]):
+        h1 = D["maxop"]>=intf_p1
+        # nmr of paths crossing lambda_i for each ensemble
+        nj = np.sum(w[:,:i+1], axis=0)
+        # nmr of paths crossing lambda_i+1 for each ensemble
+        njl = np.sum(h1*w[:,:i+1], axis=0)
+        ploc_unscaled[i+1] = njl[i]/nj[i]
+        ploc_wham[i+1] = np.sum(njl)/np.sum(nj/ploc_wham[:i+1])
+
+    A = np.zeros_like(D["maxop"])
+    Q = 1/np.cumsum(nj/ploc_wham[:-1])
+
+    for j,pathnr in enumerate(D["pnr"][:, 0]):
+        # unbiased weight of each path
+        K = min(np.where(D["maxop"][j]>interfaces)[0][-1], len(interfaces)-2)
+        A[j] = Q[K]*np.sum(w[j])
+
+    print(f"\nAll done! Weights saved to {out}.")
+    np.savetxt(out, np.c_[D["pnr"],D["maxop"],A],
+            header="path_nr\tmax_op\tweight",
+            fmt=["%8d","%8.4f", "%16.8e"])

--- a/inftools/tistools/path_weigths.py
+++ b/inftools/tistools/path_weigths.py
@@ -7,9 +7,10 @@ def get_path_weights(
         out: Annotated[str, typer.Option("-out", help = "Output .txt of the path weights")] = "path_weights.txt",
         nskip: Annotated[int, typer.Option("-nskip", help = "Skip the first nskip entries of the infretis_data.txt file")] = 0
         ):
-    """Calculate the unbiased weight for each path in the plus ensembles.
+    """Work in progress: Calculate the unbiased weight for paths in the plus ensembles.
 
-    Can be used to calculate observables as <O> = sum(wi*Oi).
+    Can be used to calculate observables as <O> = sum(wi*Oi) or for predictive power.
+    Note: The weights may be off, as this is still WIP.
     """
     import numpy as np
     import tomli


### PR DESCRIPTION
When generating zero paths with infinit, we return the `max_op` seen for the two paths such that we can place `N-1` worker additional interfaces below `max_op`. The `max_op` should however only be calculated for the [0+] path.