### PR TITLE
Allow for 1-dimensional free energy calculations

### DIFF
--- a/inftools/analysis/Free_energy.py
+++ b/inftools/analysis/Free_energy.py
@@ -1,82 +1,68 @@
 import os
 import numpy as np
 
-def extract(trajfile, xcol, ycol):
+def extract(trajfile, xcol, ycol=None):
     # Read and process the file
-    with open(trajfile) as file:
-        # Use a list comprehension to extract non-comment lines
-        lines = [line for line in file if not line.startswith("#")]
-        # Use another list comprehension to extract values from columns
-        data = [
-            (float(line.split()[xcol]), float(line.split()[ycol]))
-            for line in lines
-        ]
-        # delete first and last timeslices
-        del data[0]
-        del data[-1]
-        # Unzip the data into separate lists
+    traj = np.loadtxt(trajfile)
+    data = traj[1:-1, xcol] # remove first and last frames
+    if ycol is not None:
+        data = np.vstack((data, traj[1:-1, ycol]))
     return data
 
 
-def update_histogram(xy, factor, histogram, Minx, Miny, dx, dy):
-    for timeslice in xy:
-        x = timeslice[0]
-        y = timeslice[1]
-        ix = int((x - Minx) / dx)
-        iy = int((y - Miny) / dy)
-        histogram[ix, iy] += factor
+def update_histogram(data, factor, histogram, Minx, Miny, dx, dy):
+    if Miny is not None and dy is not None:
+        x = data[0]
+        y = data[1]
+
+        ix = ((x - Minx) / dx).astype(int)
+        iy = ((y - Miny) / dy).astype(int)
+
+        np.add.at(histogram, (ix, iy), factor)
+
+    else:
+        x = data if data.ndim == 1 else data[:,0] # make sure x is one dimensional
+        ix = ((x - Minx) / dx).astype(int)
+        np.add.at(histogram, ix, factor)
+
     return histogram
-
-
-def printhisto(xval, yval, histogram, ofile):
-    with open(ofile, "w") as file:
-        # Find the maximum length of any value in the histogram
-        strlength = 25
-        ystr = [str(y).rjust(strlength) for y in yval]
-        row = " " * (strlength - 3) + r"x\y" + "|" + " ".join(ystr)
-        file.write(row + "\n")
-        row = "-" * len(row)
-        file.write(row + "\n")
-
-        # Write the x-values and histogram values in subsequent rows
-        for i in range(histogram.shape[0]):
-            x = xval[i]
-            values_for_x = histogram[i, :]
-            formatted_values = [
-                str(val).rjust(strlength) for val in values_for_x
-            ]
-            row = str(x).rjust(strlength) + "|" + " ".join(formatted_values)
-            file.write(row + "\n")
 
 
 def calculate_free_energy(trajlabels, WFtot, Trajdir, outfolder, histo_stuff):
     print("We are now going to perform the Landau Free Energy calculations")
-    print(
-        "Check Free_energy.py and modify to your needs"
-        + " as it contains some hard coded pytrhon script."
-    )
     Nbinsx, Nbinsy = histo_stuff["nbx"], histo_stuff["nby"]
     Maxx, Minx = histo_stuff["maxx"], histo_stuff["minx"]
     Maxy, Miny = histo_stuff["maxy"], histo_stuff["miny"]
     xcol, ycol = histo_stuff["xcol"], histo_stuff["ycol"]
-
-    histogram = np.zeros((Nbinsx, Nbinsy))
+    
+    if any(var is None for var in [Nbinsy, Maxy, Miny, ycol]):
+        none_vars = [name for name, var in zip(["nby", "maxy", "miny", "ycol"], [Nbinsy, Maxy, Miny, ycol]) if var is None]
+        assert all(var is None for var in [Nbinsy, Maxy, Miny, ycol]), \
+            f"The following variables are None and should be set: {', '.join(none_vars)}"
+    if Nbinsy is not None:
+        histogram = np.zeros((Nbinsx, Nbinsy))
+        dy = (Maxy - Miny) / Nbinsy
+        yval = [Miny + 0.5 * dy + i * dy for i in range(Nbinsy)]
+    else:
+        histogram = np.zeros(Nbinsx)
+        dy = None
+        yval = None
     dx = (Maxx - Minx) / Nbinsx
-    dy = (Maxy - Miny) / Nbinsy
     xval = [Minx + 0.5 * dx + i * dx for i in range(Nbinsx)]
-    yval = [Miny + 0.5 * dy + i * dy for i in range(Nbinsy)]
-    # mid-points of the bins
+
     for label, factor in zip(trajlabels, WFtot):
         trajfile = Trajdir + "/" + str(label) + "/order.txt"
-        xy = extract(trajfile, xcol, ycol)
-        histogram = update_histogram(xy, factor, histogram, Minx, Miny, dx, dy)
+        data = extract(trajfile, xcol, ycol)
+        histogram = update_histogram(data, factor, histogram, Minx, Miny, dx, dy)
+
     # normalize such that the highest value equals 1
     max_value = np.max(histogram)
     histogram /= max_value
-    #printhisto(xval, yval, histogram, f"{outfolder}/histogram_output.txt")
+
     np.savetxt(os.path.join(outfolder, "histo_xval.txt"), xval)
-    np.savetxt(os.path.join(outfolder, "histo_yval.txt"), yval)
+    if not yval is None:
+        np.savetxt(os.path.join(outfolder, "histo_yval.txt"), yval)
     np.savetxt(os.path.join(outfolder, "histo_probability.txt"), histogram)
+    
     histogram = -np.log(histogram)  # get Landau free energy in kBT units
     np.savetxt(os.path.join(outfolder, "histo_free_energy.txt"), histogram)
-    #printhisto(xval, yval, histogram, "free_energy_output.txt")

--- a/inftools/analysis/wham.py
+++ b/inftools/analysis/wham.py
@@ -17,13 +17,13 @@ def wham(
     folder: Annotated[str, typer.Option("-folder", help="Output folder")] = "wham",
     fener: Annotated[bool, typer.Option("-fener", help="If set, calculate the conditional free energy. See Wham_")] = False,
     nbx: Annotated[int, typer.Option("-nbx", help="Number of bins in x-direction when calculating the free-energy")] = 100,
-    nby: Annotated[int, typer.Option("-nby", help="Same as -nby but in y-direction")] = 100,
+    nby: Annotated[int, typer.Option("-nby", help="Same as -nbx but in y-direction")] = None,
     minx: Annotated[float, typer.Option("-minx", help="Minimum orderparameter value in the x-direction when calculating FE")] = 0.0,
     maxx: Annotated[float, typer.Option("-maxx", help="Maximum orderparameter value in the x-direction when calculating FE")] = 100.0,
-    miny: Annotated[float, typer.Option("-miny", help="Same as -minx but in y-direction")] = 0.0,
-    maxy: Annotated[float, typer.Option("-maxy", help="Same as -maxx but in y-direction")] = 360.0,
+    miny: Annotated[float, typer.Option("-miny", help="Same as -minx but in y-direction")] = None,
+    maxy: Annotated[float, typer.Option("-maxy", help="Same as -maxx but in y-direction")] = None,
     xcol: Annotated[int, typer.Option("-xcol", help="What column in order.txt to use as x-value when calculating FE")] = 1,
-    ycol: Annotated[int, typer.Option("-ycol", help="Same as -xcol but for y-value")] = 2,
+    ycol: Annotated[int, typer.Option("-ycol", help="Same as -xcol but for y-value")] = None,
     ):
     """Run Titus0 wham script."""
 


### PR DESCRIPTION
The variables related to the second order parameter become optional. Also streamline and simplify some calculations. 
1D free energy calculations can be run by omitting everything related to the second (y) order parameter, e.g.:
inft wham -data infretis_data.txt -toml infretis.toml -lamres 0.001 -nskip 2000 -fener -nbx 100 -xcol 4 -minx 5.0 -maxx 8.0