### PR TITLE
Fix: support for lambda_minus_one in WHAM

### DIFF
--- a/inftools/analysis/Wham_Pcross.py
+++ b/inftools/analysis/Wham_Pcross.py
@@ -16,6 +16,7 @@ def run_analysis(inp_dic):
     nskip = int(inp_dic["nskip"])
     folder = inp_dic["folder"]
     histo_stuff = inp_dic["histo_stuff"]
+    lm1 = inp_dic["lm1"]
 
     # the Cxy values of [0+] are stored in the i0plus-th
     # column (first coulumn is counted as column nr 0)
@@ -334,6 +335,8 @@ def run_analysis(inp_dic):
                 if lmax == intfQ[0] and L > 2:
                     indexQ == 0
                     # round-off issue that should not lead to an exit
+                elif lm1 is not None:
+                    indexQ == 0
                 else:
                     print(
                         "Error: lambda_max is lower or equal"
@@ -353,7 +356,7 @@ def run_analysis(inp_dic):
     print("Remove redundant routine!!!!!!!!")
 
     # Alternative approach
-    WHAMfactors = get_WHAMfactors(matrix, lambda_interfaces, i0plus, Q)
+    WHAMfactors = get_WHAMfactors(matrix, lambda_interfaces, i0plus, Q, lm1)
     # gives for each path the \chi(X) factor from which we
     # can compute any ensemble average < property(X)  >_[0^+] as
     # sum_X A(X) Chi(X)
@@ -396,6 +399,8 @@ def run_analysis(inp_dic):
                 if lmax == intfQ[0] and L > 2:
                     indexH == 0
                     # round-off issue that should not lead to an exit
+                elif lm1 is not None:
+                    indexH == 0
                 else:
                     print(
                         "Error: lambda_max is lower or equal"

--- a/inftools/analysis/toolsWHAM.py
+++ b/inftools/analysis/toolsWHAM.py
@@ -1,4 +1,4 @@
-def get_WHAMfactors(matrix, lambda_interfaces, i0plus, Q):
+def get_WHAMfactors(matrix, lambda_interfaces, i0plus, Q, lm1):
     imax = 2  # index where lambda_max is stored
     intfQ = lambda_interfaces[
         :-1
@@ -16,6 +16,8 @@ def get_WHAMfactors(matrix, lambda_interfaces, i0plus, Q):
             if lmax == intfQ[0]:
                 indexQ == 0
                 # round-off issue that should not lead to an exit
+            elif lm1 is not None:
+                indexQ == 0
             else:
                 print(
                     "Error: lambda_max is lower or equal to all TIS interfaces"

--- a/inftools/analysis/wham.py
+++ b/inftools/analysis/wham.py
@@ -49,6 +49,7 @@ def wham(
         print("No toml file, exit.")
         return
     inps["intfs"] = config["simulation"]["interfaces"]
+    inps["lm1"] = config["simulation"]["tis_set"].get("lambda_minus_one", None)
 
     if inps["lamres"] is None:
         inps["lamres"] = (inps["intfs"][1] - inps["intfs"][0]) / 10


### PR DESCRIPTION
The code previously checked whether all lambda_max values in infretis_data.txt were less than or equal to the TIS interfaces. This caused issues when the lambda_minus_one setting was enabled, because the LML path associated with lambda_minus_one has a lambda_max value lower than lambda_A. This check was performed in three different places in the code. The update modifies the logic so that if lambda_minus_one is defined, those specific checks are skipped.