### PR TITLE
add turtlemd

### DIFF
--- a/.github/workflows/biweekly.yml
+++ b/.github/workflows/biweekly.yml
@@ -42,5 +42,8 @@ jobs:
       - name: "Install"
         run: poetry install
 
+      - name: "Install turtlemd"
+        run: pip install turtlemd
+
       - name: "Run pytest"
         run: poetry run pytest test


### PR DESCRIPTION
I think both test_shoot and test_infinit fails because we did not include installing turtlemd in the pipeline. This fix includes this install.

https://github.com/infretis/inftools/actions/runs/17722985807