### PR TITLE
load dir option plot_ens

### DIFF
--- a/inftools/tistools/plot_ens.py
+++ b/inftools/tistools/plot_ens.py
@@ -33,7 +33,7 @@ def plot_ens(
     if not toml["output"].get("data_file", False) and not data:
         exit("Supply a infretis_data.txt file with -data")
     elif data:
-        print("Using {data}")
+        print(f"Using {data}")
         datafile = data
     else:
         datafile = toml["output"]["data_file"]


### PR DESCRIPTION
fixes some stuff in plot_ens, such as an option to
* provide .toml (used hardcoded restart.toml before)
* provide infreits_data if toml doesn't have this
* provide a different load dir