### PR TITLE
infinit without run folders

### DIFF
--- a/inftools/analysis/wham.py
+++ b/inftools/analysis/wham.py
@@ -1,5 +1,6 @@
-from typing import Annotated
+from typing import Annotated as Atd
 import typer
+from typer import Option as Opt
 
 import os
 
@@ -9,21 +10,21 @@ from inftools.analysis.Wham_Pcross import run_analysis
 
 
 def wham(
-    toml: Annotated[str, typer.Option("-toml", help="The infretis .toml file")] = "infretis.toml",
-    data: Annotated[str, typer.Option("-data", help="The infretis_data.txt file")] = "infretis_data.txt",
-    nskip: Annotated[int, typer.Option("-nskip", help="Number of lines to skip in infretis_data.txt")] = 100,
-    lamres: Annotated[float, typer.Option("-lamres", help="Resolution along the orderparameter, (intf1-intf0)/10)")] = None,
-    nblock: Annotated[int, typer.Option("-nblock", case_sensitive=False, help="Minimal number of blocks in the block-error analysis")] = 5,
-    folder: Annotated[str, typer.Option("-folder", help="Output folder")] = "wham",
-    fener: Annotated[bool, typer.Option("-fener", help="If set, calculate the conditional free energy. See Wham_")] = False,
-    nbx: Annotated[int, typer.Option("-nbx", help="Number of bins in x-direction when calculating the free-energy")] = 100,
-    nby: Annotated[int, typer.Option("-nby", help="Same as -nbx but in y-direction")] = None,
-    minx: Annotated[float, typer.Option("-minx", help="Minimum orderparameter value in the x-direction when calculating FE")] = 0.0,
-    maxx: Annotated[float, typer.Option("-maxx", help="Maximum orderparameter value in the x-direction when calculating FE")] = 100.0,
-    miny: Annotated[float, typer.Option("-miny", help="Same as -minx but in y-direction")] = None,
-    maxy: Annotated[float, typer.Option("-maxy", help="Same as -maxx but in y-direction")] = None,
-    xcol: Annotated[int, typer.Option("-xcol", help="What column in order.txt to use as x-value when calculating FE")] = 1,
-    ycol: Annotated[int, typer.Option("-ycol", help="Same as -xcol but for y-value")] = None,
+    toml: Atd[str, Opt("-toml", help="The infretis .toml file")] = "infretis.toml",
+    data: Atd[str, Opt("-data", help="The infretis_data.txt file")] = "infretis_data.txt",
+    nskip: Atd[int, Opt("-nskip", help="Number of lines to skip in infretis_data.txt")] = 100,
+    lamres: Atd[float, Opt("-lamres", help="Resolution along the orderparameter, (intf1-intf0)/10)")] = None,
+    nblock: Atd[int, Opt("-nblock", case_sensitive=False, help="Minimal number of blocks in the block-error analysis")] = 5,
+    folder: Atd[str, Opt("-folder", help="Output folder")] = "wham",
+    fener: Atd[bool, Opt("-fener", help="If set, calculate the conditional free energy. See Wham_")] = False,
+    nbx: Atd[int, Opt("-nbx", help="Number of bins in x-direction when calculating the free-energy")] = 100,
+    nby: Atd[int, Opt("-nby", help="Same as -nbx but in y-direction")] = None,
+    minx: Atd[float, Opt("-minx", help="Minimum orderparameter value in the x-direction when calculating FE")] = 0.0,
+    maxx: Atd[float, Opt("-maxx", help="Maximum orderparameter value in the x-direction when calculating FE")] = 100.0,
+    miny: Atd[float, Opt("-miny", help="Same as -minx but in y-direction")] = None,
+    maxy: Atd[float, Opt("-maxy", help="Same as -maxx but in y-direction")] = None,
+    xcol: Atd[int, Opt("-xcol", help="What column in order.txt to use as x-value when calculating FE")] = 1,
+    ycol: Atd[int, Opt("-ycol", help="Same as -xcol but for y-value")] = None,
     ):
     """Run Titus0 wham script."""
 
@@ -58,6 +59,6 @@ def wham(
         inps["lamres"] = (inps["intfs"][1] - inps["intfs"][0]) / 10
 
     if inps["fener"]:
-        inps["trajdir"] = config["simulation"]["load_dir"]
+        inps["trajdir"] = config["simulation"].get("load_dir", "load")
 
     run_analysis(inps)

--- a/inftools/exercises/puckering.py
+++ b/inftools/exercises/puckering.py
@@ -146,6 +146,7 @@ def initial_path_from_iretis(
     out_toml: Annotated[str, typer.Option("-out_toml", help="Output file if interfaces and shooting_moves are chagned")] = "",
     keep_all_active: Annotated[bool, typer.Option(help = "If active paths are no longer valid, add new interfaces")] = False,
     active_path_dir: Annotated[str, typer.Option(help = "Directory to the active paths ('-traj' if not given)")] = "",
+    return_pathnr: Annotated[bool, typer.Option(help = "Only return the path numbers for each ensemble")] = False,
     ):
     """Pick out initial paths from an earlier infretis simulation.
 
@@ -181,13 +182,14 @@ def initial_path_from_iretis(
     if out_toml:
         out_toml = pathlib.Path(out_toml)
 
-    if out_dir.exists():
-        raise ValueError(
-            f"Directory {out_dir.resolve()} exists. Will not overwrite. "
-            "Rename or delete it manually. Aborting."
-        )
-    else:
-        os.mkdir(out_dir)
+    if not return_pathnr:
+        if out_dir.exists():
+            raise ValueError(
+                f"Directory {out_dir.resolve()} exists. Will not overwrite. "
+                "Rename or delete it manually. Aborting."
+            )
+        else:
+            os.mkdir(out_dir)
 
     # read interfaces from .toml file
     with open(toml, "rb") as toml_file:
@@ -356,11 +358,13 @@ def initial_path_from_iretis(
         ), f"* Did not find any paths in ensemble {i}\
     that cross the corresponding interface"
 
+    if not return_pathnr:
+        for i, traj in zip(out.keys(), out.values()):
+            shutil.copytree(traj, out_dir / str(i))
 
-    for i, traj in zip(out.keys(), out.values()):
-        shutil.copytree(traj, out_dir / str(i))
-
-    print(f"\nAll done! Created folder {out_dir} with new initial paths.")
+        print(f"\nAll done! Created folder {out_dir} with new initial paths.")
+    else:
+        return out
 
 def initial_path_from_md(
         trr: Annotated[str, typer.Option("-trr", help="The .trr trajectory file")],

--- a/inftools/misc/infinit_helper.py
+++ b/inftools/misc/infinit_helper.py
@@ -157,20 +157,20 @@ def update_toml_interfaces(config):
     skip = []
     # use inft combine_data with previous combo.txt (if it exists)
     # and current infretis_data.txt file
-    if pl.Path(f"combo_{cstep-1}.toml").exists() and pl.Path(f"combo_{cstep-1}.txt").exists():
-        tomls += [f"combo_{cstep-1}.toml"]
-        datas += [f"combo_{cstep-1}.txt"]
+    if pl.Path(f"combo_{cstep}.toml").exists() and pl.Path(f"combo_{cstep}.txt").exists():
+        tomls += [f"combo_{cstep}.toml"]
+        datas += [f"combo_{cstep}.txt"]
         skip += [0]
     combine_data(
             tomls = tomls + ["restart.toml"],
             datas = datas + [config1["output"]["data_file"]],
-            out=f"combo_{cstep}",
+            out=f"combo_{cstep+1}",
             skip= skip + [int(config1["current"]["cstep"]*config1["infinit"]["skip"])],
             )
     # calculate crossing probability for interface estimation
     xp = get_path_weights(
-        toml = f"combo_{cstep}.toml",
-        data = f"combo_{cstep}.txt",
+        toml = f"combo_{cstep+1}.toml",
+        data = f"combo_{cstep+1}.txt",
         nskip = 0,
         outP = "last_infretis_pcross.txt",
         out = "last_infretis_path_weigths.txt",

--- a/inftools/misc/infinit_helper.py
+++ b/inftools/misc/infinit_helper.py
@@ -230,17 +230,19 @@ def update_actives_toml(out):
     # remove frac entry from infretis.toml
     config0["current"]["frac"] = {}
     config0["current"]["cstep"] = 0
+    config0["current"].pop("restarted_from")
     traj_num = config0["current"]["traj_num"]
     active = []
     print(out)
     #  rename active paths for next round
-    for i, path in enumerate(out.values()):
+    for i, path in out.items():
         new_path_nr = traj_num + i
         active.append(new_path_nr)
         path_new = path.parent/f"{new_path_nr}"
         path_new.symlink_to(path.resolve(), target_is_directory=True)
     # traj_num should be 1 larger than largest path nr
-    config0["current"]["traj_num"] = new_path_nr + 1
+    print(active)
+    config0["current"]["traj_num"] = max(active) + 1
     config0["current"]["active"] = active
     config0["current"]["size"] = len(active)
     config0["output"]["data_file"] = f"infretis_data_{config0['infinit']['cstep']+1}.txt"

--- a/inftools/misc/infinit_helper.py
+++ b/inftools/misc/infinit_helper.py
@@ -240,6 +240,29 @@ def update_toml(config):
     shutil.copyfile("infretis.toml", f"infretis_{config['infinit']['cstep']}.toml")
     write_toml(config0, "infretis.toml")
 
+def update_actives_toml(out):
+    config0 = read_toml("infretis.toml")
+    config1 = read_toml("restart.toml")
+    config0["current"] = config1["current"]
+    # remove frac entry from infretis.toml
+    config0["current"]["frac"] = {}
+    config0["current"]["cstep"] = 0
+    traj_num = config0["current"]["traj_num"]
+    active = []
+    print(out)
+    #  rename active paths for next round
+    for i, path in enumerate(out.values()):
+        new_path_nr = traj_num + i
+        active.append(new_path_nr)
+        path_new = path.parent/f"{new_path_nr}"
+        path_new.symlink_to(path.resolve(), target_is_directory=True)
+    # traj_num should be 1 larger than largest path nr
+    config0["current"]["traj_num"] = new_path_nr + 1
+    config0["current"]["active"] = active
+    config0["current"]["size"] = len(active)
+    config0["output"]["data_file"] = f"infretis_data_{config0['infinit']['cstep']+1}.txt"
+    write_toml(config0, "infretis.toml")
+
 def print_logo(step: int = 0):
     from rich.console import Console
     from rich.text import Text

--- a/inftools/misc/infinit_helper.py
+++ b/inftools/misc/infinit_helper.py
@@ -215,23 +215,6 @@ def update_toml_interfaces(config):
     config["simulation"]["interfaces"] =intf[:1] +  intf_tmp + intf[-1:]
     config["simulation"]["shooting_moves"] = sh_moves = ["sh", "sh"] + ["wf" for i in range(len(intf)-2)]
 
-def update_folders():
-    config = read_toml("infretis.toml")
-    old_dir = pl.Path(config["simulation"]["load_dir"])
-    new_dir = pl.Path(f"run{config['infinit']['cstep']}")
-    if new_dir.exists():
-        msg = (f"{str(new_dir)} allready exists! Infinit does not "
-                + "overwrite.")
-        print(msg)
-        if not old_dir.exists():
-            print("Did not find {old_dir}.")
-            return False
-
-        return True
-
-    shutil.move(old_dir, new_dir)
-    return False
-
 def update_toml(config):
     config0 = read_toml("infretis.toml")
     config0["simulation"]["interfaces"] = config["simulation"]["interfaces"]

--- a/inftools/tistools/initial_paths.py
+++ b/inftools/tistools/initial_paths.py
@@ -244,11 +244,10 @@ def infinit(
         msg += ", ".join([str(intf) for intf in config["simulation"]["interfaces"]])
         msg += "]"
         log.log(msg)
-        log.log("Moving and writing files.")
-        has_load = update_folders()
+        #log.log("Moving and writing files.")
+        #has_load = update_folders()
         iset["cstep"] += 1
         update_toml(config)
-        if not has_load:
-            initial_path_from_iretis("run*", "infretis.toml", restart = "restart.toml", active_path_dir=f"run{iset['cstep']-1}")
-        else:
-            print("Doesnt have load?")
+        out = initial_path_from_iretis("load", "infretis.toml", restart = "restart.toml", active_path_dir=f"load", return_pathnr = True)
+        # update infretis.toml to be a restart.toml
+        update_actives_toml(out)

--- a/inftools/tistools/shoot.py
+++ b/inftools/tistools/shoot.py
@@ -86,13 +86,14 @@ def shoot(
     path = Path()
     shooting_point = System()
     shooting_point.config = (conf, index)
+    engine.dump_phasepoint(shooting_point)
     # calculate order, this defines the starting conditions
     # if op < intf[0] we assume [0-] path
     # if op >= intf[0] and op < intf[-1] we assume [N+] path
     # if op >= intf[-1] what should we do?
     # modify velocities, which dumps the shooting point to genvel.ext
-    engine.modify_velocities(shooting_point, config["simulation"]["tis_set"])
     # now calculate orderp after vel generation, as order may depend on vels
+    engine.modify_velocities(shooting_point, config["simulation"]["tis_set"])
     order = engine.calculate_order(shooting_point)
     shooting_point.order = order
     print(f"* Initial orderparameter value: {order}")


### PR DESCRIPTION
* infinit now uses symlinks to create new paths instead of copying old paths
* name infretis_data files `infretis_data_cstep.txt` where cstep is the infinit step, to more easily match infretis_x.toml and infretis_data_y.txt
* add an interface header to infretis_data files during infinit runs
* remove run/ folders, such that one can use the `-fener` flag when whamming the combo files
* add default `load_dir` when running `inft wham`
* small bugfix shoot.py for some engines