### PR TITLE
use internalrun instead of subprocess

### DIFF
--- a/inftools/misc/infinit_helper.py
+++ b/inftools/misc/infinit_helper.py
@@ -1,5 +1,4 @@
 import shutil
-import subprocess
 
 import pathlib as pl
 
@@ -103,11 +102,12 @@ def write_toml(config, toml):
         tomli_w.dump(config, wfile)
 
 def run_infretis_ext(steps):
-    """Run infretis as a subprocess.
+    """Run infretis.
 
     Returns True if successful run, else False.
     """
     import numpy as np
+    import infretis.bin
     c0 = read_toml("infretis.toml")
     c1 = read_toml("restart.toml")
     if c1 and c0["infinit"]["cstep"] == c1["infinit"]["cstep"] and len(c0["simulation"]["interfaces"])==len(c1["simulation"]["interfaces"]) and np.allclose(c0["simulation"]["interfaces"],c1["simulation"]["interfaces"]):
@@ -116,12 +116,12 @@ def run_infretis_ext(steps):
         # might have updated steps_per_iter
         c1["infinit"]["steps_per_iter"] = c0["infinit"]["steps_per_iter"]
         write_toml(c1, "restart.toml")
-        subprocess.run("infretisrun -i restart.toml", shell = True)
+        infretis.bin.internalrun("restart.toml")
     else:
         print("Running with infretis.toml")
         c0["simulation"]["steps"] = steps
         write_toml(c0, "infretis.toml")
-        subprocess.run("infretisrun -i infretis.toml", shell = True)
+        infretis.bin.internalrun("infretis.toml")
     # check if successful run
     c1 = read_toml("restart.toml")
     if not c1:

--- a/inftools/misc/infinit_helper.py
+++ b/inftools/misc/infinit_helper.py
@@ -101,13 +101,23 @@ def write_toml(config, toml):
     with open(toml, "wb") as wfile:
         tomli_w.dump(config, wfile)
 
+def infretisrun_internal(runfile):
+    import logging
+    import infretis.bin
+    infretis.bin.internalrun(runfile)
+    # needed to not run multiple times to same sim.log
+    # when using infretis.bin.internalrun
+    logger = logging.getLogger("main")
+    for handler in logger.handlers[:]:
+        handler.close()
+        logger.removeHandler(handler)
+
 def run_infretis_ext(steps):
     """Run infretis.
 
     Returns True if successful run, else False.
     """
     import numpy as np
-    import infretis.bin
     c0 = read_toml("infretis.toml")
     c1 = read_toml("restart.toml")
     if c1 and c0["infinit"]["cstep"] == c1["infinit"]["cstep"] and len(c0["simulation"]["interfaces"])==len(c1["simulation"]["interfaces"]) and np.allclose(c0["simulation"]["interfaces"],c1["simulation"]["interfaces"]):
@@ -116,12 +126,12 @@ def run_infretis_ext(steps):
         # might have updated steps_per_iter
         c1["infinit"]["steps_per_iter"] = c0["infinit"]["steps_per_iter"]
         write_toml(c1, "restart.toml")
-        infretis.bin.internalrun("restart.toml")
+        infretisrun_internal("restart.toml")
     else:
         print("Running with infretis.toml")
         c0["simulation"]["steps"] = steps
         write_toml(c0, "infretis.toml")
-        infretis.bin.internalrun("infretis.toml")
+        infretisrun_internal("infretis.toml")
     # check if successful run
     c1 = read_toml("restart.toml")
     if not c1:

--- a/inftools/misc/infinit_helper.py
+++ b/inftools/misc/infinit_helper.py
@@ -59,7 +59,7 @@ def set_default_infinit(config):
     # check that interfaces are multiples of lamres
     # but skip for first iteration
     if cstep not in [-1,0]:
-        rounded_intf = np.round(np.floor(interfaces/lamres)*lamres, decimals=10)
+        rounded_intf = np.round(np.floor(np.round(interfaces/lamres,decimals=10))*lamres, decimals=10)
         err_intf = np.where(rounded_intf != interfaces)[0]
         err_msg = (
             f"Interfaces {interfaces[err_intf]} are not multiples of "
@@ -233,7 +233,7 @@ def update_toml_interfaces(config):
         intf[-2] = x[-1] - lamres
     # always round new interfaces *down* so we  don't accidentally round the
     # second-to-last interface above the highest maxop of the highest path
-    intf_tmp = np.round(np.floor(np.array(intf[1:-1])/lamres)*lamres, decimals=10)
+    intf_tmp = np.round(np.floor(np.round(np.array(intf[1:-1])/lamres,decimals=10))*lamres, decimals=10)
     # remove duplicates if any appear due to rounding of interfaces
     intf_tmp = list(np.unique(intf_tmp))
     # if we suddenly have less workers than interfaces, just return the


### PR DESCRIPTION
* Use internalrun instead of launching a subprocess when running infretis in inf-init. Forgot to change this when I first implemented inf-init.
* Fix rounding errors when checking if interfaces are multiples of lamres.