### PR TITLE
Calc replica flow for infinit simulations

### DIFF
--- a/inftools/misc/infinit_helper.py
+++ b/inftools/misc/infinit_helper.py
@@ -1,5 +1,4 @@
 import shutil
-import subprocess
 
 import pathlib as pl
 
@@ -103,11 +102,12 @@ def write_toml(config, toml):
         tomli_w.dump(config, wfile)
 
 def run_infretis_ext(steps):
-    """Run infretis as a subprocess.
+    """Run infretis.
 
     Returns True if successful run, else False.
     """
     import numpy as np
+    import infretis.bin
     c0 = read_toml("infretis.toml")
     c1 = read_toml("restart.toml")
     if c1 and c0["infinit"]["cstep"] == c1["infinit"]["cstep"] and len(c0["simulation"]["interfaces"])==len(c1["simulation"]["interfaces"]) and np.allclose(c0["simulation"]["interfaces"],c1["simulation"]["interfaces"]):
@@ -116,12 +116,12 @@ def run_infretis_ext(steps):
         # might have updated steps_per_iter
         c1["infinit"]["steps_per_iter"] = c0["infinit"]["steps_per_iter"]
         write_toml(c1, "restart.toml")
-        subprocess.run("infretisrun -i restart.toml", shell = True)
+        infretis.bin.internalrun("restart.toml")
     else:
         print("Running with infretis.toml")
         c0["simulation"]["steps"] = steps
         write_toml(c0, "infretis.toml")
-        subprocess.run("infretisrun -i infretis.toml", shell = True)
+        infretis.bin.internalrun("infretis.toml")
     # check if successful run
     c1 = read_toml("restart.toml")
     if not c1:

--- a/inftools/misc/infinit_helper.py
+++ b/inftools/misc/infinit_helper.py
@@ -101,13 +101,23 @@ def write_toml(config, toml):
     with open(toml, "wb") as wfile:
         tomli_w.dump(config, wfile)
 
+def infretisrun_internal(runfile):
+    import logging
+    import infretis.bin
+    infretis.bin.internalrun(runfile)
+    # needed to not run multiple times to same sim.log
+    # when using infretis.bin.internalrun
+    logger = logging.getLogger("main")
+    for handler in logger.handlers[:]:
+        handler.close()
+        logger.removeHandler(handler)
+
 def run_infretis_ext(steps):
     """Run infretis.
 
     Returns True if successful run, else False.
     """
     import numpy as np
-    import infretis.bin
     c0 = read_toml("infretis.toml")
     c1 = read_toml("restart.toml")
     if c1 and c0["infinit"]["cstep"] == c1["infinit"]["cstep"] and len(c0["simulation"]["interfaces"])==len(c1["simulation"]["interfaces"]) and np.allclose(c0["simulation"]["interfaces"],c1["simulation"]["interfaces"]):
@@ -116,12 +126,12 @@ def run_infretis_ext(steps):
         # might have updated steps_per_iter
         c1["infinit"]["steps_per_iter"] = c0["infinit"]["steps_per_iter"]
         write_toml(c1, "restart.toml")
-        infretis.bin.internalrun("restart.toml")
+        infretisrun_internal("restart.toml")
     else:
         print("Running with infretis.toml")
         c0["simulation"]["steps"] = steps
         write_toml(c0, "infretis.toml")
-        infretis.bin.internalrun("infretis.toml")
+        infretisrun_internal("infretis.toml")
     # check if successful run
     c1 = read_toml("restart.toml")
     if not c1:

--- a/inftools/misc/infinit_helper.py
+++ b/inftools/misc/infinit_helper.py
@@ -59,7 +59,7 @@ def set_default_infinit(config):
     # check that interfaces are multiples of lamres
     # but skip for first iteration
     if cstep not in [-1,0]:
-        rounded_intf = np.round(np.floor(interfaces/lamres)*lamres, decimals=10)
+        rounded_intf = np.round(np.floor(np.round(interfaces/lamres,decimals=10))*lamres, decimals=10)
         err_intf = np.where(rounded_intf != interfaces)[0]
         err_msg = (
             f"Interfaces {interfaces[err_intf]} are not multiples of "
@@ -233,7 +233,7 @@ def update_toml_interfaces(config):
         intf[-2] = x[-1] - lamres
     # always round new interfaces *down* so we  don't accidentally round the
     # second-to-last interface above the highest maxop of the highest path
-    intf_tmp = np.round(np.floor(np.array(intf[1:-1])/lamres)*lamres, decimals=10)
+    intf_tmp = np.round(np.floor(np.round(np.array(intf[1:-1])/lamres,decimals=10))*lamres, decimals=10)
     # remove duplicates if any appear due to rounding of interfaces
     intf_tmp = list(np.unique(intf_tmp))
     # if we suddenly have less workers than interfaces, just return the

--- a/inftools/misc/misc.py
+++ b/inftools/misc/misc.py
@@ -1,15 +1,13 @@
 def assign_code(log):
-    import numpy as np
     paths = {}
     codes = {}
-    replicas = []
     inits = []
     inits0 = []
     init_b = False
     shootings = []
     shooting = 0
 
-    with open(log, "r") as read:
+    with open(log) as read:
         for line in read:
             rip = line.rstrip().split()
             if "stored" in line:
@@ -39,7 +37,6 @@ def assign_code(log):
 
 
 def add_move(replica, ens_arr, old, new, ens_num):
-    import numpy as np
     replica_new = []
     ens_new = []
 
@@ -56,18 +53,16 @@ def add_move(replica, ens_arr, old, new, ens_num):
 
 
 def read_log(log, pn):
-    import numpy as np
     # what we want:
     # p0 -> p10 -> p16 -> p20 -> p23 -> p31 -> p34 -> p50
     # e0 ->  e1 ->  e0 ->  e1 ->  e1 ->  e0 ->  e0 ->  e1
 
     paths, codes, inits, shootings = assign_code(log)
-    connections = []
 
     istep = -1
     replicas = []
     ensembles = []
-    with open(log, "r") as read:
+    with open(log) as read:
         for line in read:
             rip = line.rstrip().split()
             if "stored" in line:
@@ -103,7 +98,6 @@ def read_log(log, pn):
     follow_pn = []
     follow_en = []
     follow_size = []
-    pn0 = pn
     code = paths[pn]
     for idx, replica, ensemble in zip(range(len(replicas))[::-1], replicas[::-1], ensembles[::-1]):
         for rep, ens in zip(replica, ensemble):

--- a/inftools/misc/misc.py
+++ b/inftools/misc/misc.py
@@ -16,7 +16,7 @@ def assign_code(log):
             if "shooted" in line:
                 shooting += 1
 
-            if "|" in line and rip[-4] == "|":
+            if "|" in line and rip[-4] == "|" and rip[2] == "|" and len(rip)>6:
                 pn = int(rip[1][1:])
                 if init_b:
                     inits0.append(pn)

--- a/inftools/misc/misc.py
+++ b/inftools/misc/misc.py
@@ -66,6 +66,9 @@ def read_log(log, pn):
         for line in read:
             rip = line.rstrip().split()
             if "stored" in line:
+                if istep >= len(inits) - 1:
+                    # break to avoid index error if last sim.log line is 'stored'
+                    break
                 if istep > -1:
                     replicas.append(replicas0)
                     ensembles.append(ens0)

--- a/inftools/misc/misc.py
+++ b/inftools/misc/misc.py
@@ -1,0 +1,128 @@
+def assign_code(log):
+    import numpy as np
+    paths = {}
+    codes = {}
+    replicas = []
+    inits = []
+    inits0 = []
+    init_b = False
+    shootings = []
+    shooting = 0
+
+    with open(log, "r") as read:
+        for line in read:
+            rip = line.rstrip().split()
+            if "stored" in line:
+                init_b = True
+
+            if "shooted" in line:
+                shooting += 1
+
+            if "|" in line and rip[-4] == "|":
+                pn = int(rip[1][1:])
+                if init_b:
+                    inits0.append(pn)
+                if pn not in paths:
+                    code = f"{rip[-1]}_{rip[-2]}_{rip[-3]}"
+                    paths[pn] = code
+                    shootings.append(shooting)
+                    if code not in codes:
+                        codes[code] = [pn]
+                    else:
+                        codes[code].append(pn)
+            if "submit" in line and init_b:
+                inits.append(inits0)
+                inits0 = []
+                init_b = False
+
+    return paths, codes, inits, shootings
+
+
+def add_move(replica, ens_arr, old, new, ens_num):
+    import numpy as np
+    replica_new = []
+    ens_new = []
+
+    for idx, (rep, ens)in enumerate(zip(replica, ens_arr)):
+        last = rep.split("+")[-1]
+        # last_ens = ens.split("+")[-1]
+        if old == last:
+            replica_new.append(rep + "+" + new)
+            ens_new.append(ens + "+" + ens_num)
+        else:
+            replica_new.append(rep)
+            ens_new.append(ens)
+    return replica_new, ens_new
+
+
+def read_log(log, pn):
+    import numpy as np
+    # what we want:
+    # p0 -> p10 -> p16 -> p20 -> p23 -> p31 -> p34 -> p50
+    # e0 ->  e1 ->  e0 ->  e1 ->  e1 ->  e0 ->  e0 ->  e1
+
+    paths, codes, inits, shootings = assign_code(log)
+    connections = []
+
+    istep = -1
+    replicas = []
+    ensembles = []
+    with open(log, "r") as read:
+        for line in read:
+            rip = line.rstrip().split()
+            if "stored" in line:
+                if istep > -1:
+                    replicas.append(replicas0)
+                    ensembles.append(ens0)
+                istep += 1
+                replicas0 = [f"{i}" for i in inits[istep]]
+                ens0 = [str(i) for i in range(len(replicas0))]
+
+            if "shooted" not in line:
+                continue
+
+            # zero swap
+            if "shooted" in line and len(rip) == 15:
+                pno1, pno2 = rip[-5], rip[-4]
+                pnn1, pnn2 = rip[-2], rip[-1]
+
+                replicas0, ens0 = add_move(replicas0, ens0, pno1, pnn2, str(1))
+                replicas0, ens0 = add_move(replicas0, ens0, pno2, pnn1, str(0))
+
+            # shoot
+            elif "shooted" in line:
+                pno, pnn = rip[-3], rip[-1]
+                ens = str(int(rip[-6]))
+                if pno == pnn:
+                    continue
+
+                replicas0, ens0 = add_move(replicas0, ens0, pno, pnn, ens)
+    replicas.append(replicas0)
+    ensembles.append(ens0)
+
+    follow_pn = []
+    follow_en = []
+    follow_size = []
+    pn0 = pn
+    code = paths[pn]
+    for idx, replica, ensemble in zip(range(len(replicas))[::-1], replicas[::-1], ensembles[::-1]):
+        for rep, ens in zip(replica, ensemble):
+            rep_codesl = [paths[int(pn0)] for pn0 in rep.split("+")]
+            rep_codes = "+".join(rep_codesl)
+            if code in rep_codes:
+                follow_pn.append(rep)
+                follow_en.append(ens)
+                code = paths[int(rep.split("+")[0])]
+                break
+        follow_size.append((len(replica), len(rep_codesl)))
+
+    pns = ("+".join(follow_pn[::-1])).split("+")
+    ens = ("+".join(follow_en[::-1])).split("+")
+
+    paths = list(paths.keys())
+    shootings0 = {pn: sht for pn, sht in zip(paths, shootings)}
+    shootings1 = []
+    for pn in pns:
+        shootings1.append(shootings0[int(pn)])
+
+    return ens, pns, follow_size[::-1], shootings1

--- a/inftools/misc/misc.py
+++ b/inftools/misc/misc.py
@@ -1,4 +1,13 @@
 def assign_code(log):
+    """
+    inp: sim.log
+
+    Assign unique path identifiers "code" for pns, that are not
+    necessarily unique.
+
+    Additionally, returns the pns for each infinit round and
+    the total amount of shooting attempts performed.
+    """
     paths = {}
     codes = {}
     inits = []
@@ -21,7 +30,8 @@ def assign_code(log):
                 if init_b:
                     inits0.append(pn)
                 if pn not in paths:
-                    code = f"{rip[-1]}_{rip[-2]}_{rip[-3]}"
+                    # sometimes there is rounding in the OP
+                    code = f"{rip[-1]}_{rip[-2][:-1]}_{rip[-3][:-1]}"
                     paths[pn] = code
                     shootings.append(shooting)
                     if code not in codes:
@@ -37,6 +47,9 @@ def assign_code(log):
 
 
 def add_move(replica, ens_arr, old, new, ens_num):
+    """
+    Add the new path pn and ensemble to the replica pn and ens list.
+    """
     replica_new = []
     ens_new = []
 
@@ -52,16 +65,24 @@ def add_move(replica, ens_arr, old, new, ens_num):
     return replica_new, ens_new
 
 
-def read_log(log, pn):
-    # what we want:
-    # p0 -> p10 -> p16 -> p20 -> p23 -> p31 -> p34 -> p50
-    # e0 ->  e1 ->  e0 ->  e1 ->  e1 ->  e0 ->  e0 ->  e1
+def step_flow(log, inits):
+    """
+    Return the replica flows individual infinit steps (infretis run)
+    and their associated ensmbes
 
-    paths, codes, inits, shootings = assign_code(log)
-
+    e.g. for 1 infinit step,
+    p0
+    p1>p4
+    p2>p5
+    p3
+    meaning only p1 and p2 had successful shooting moves and so on
+    for other steps.
+    """
     istep = -1
     replicas = []
     ensembles = []
+    imcsteps = []
+    imcsteps0 = 0
     with open(log) as read:
         for line in read:
             rip = line.rstrip().split()
@@ -72,12 +93,15 @@ def read_log(log, pn):
                 if istep > -1:
                     replicas.append(replicas0)
                     ensembles.append(ens0)
+                    imcsteps.append(imcsteps0)
+                    imcsteps0 = 0
                 istep += 1
                 replicas0 = [f"{i}" for i in inits[istep]]
                 ens0 = [str(i) for i in range(len(replicas0))]
 
             if "shooted" not in line:
                 continue
+            imcsteps0 += 1
 
             # zero swap
             if "shooted" in line and len(rip) == 15:
@@ -97,7 +121,24 @@ def read_log(log, pn):
                 replicas0, ens0 = add_move(replicas0, ens0, pno, pnn, ens)
     replicas.append(replicas0)
     ensembles.append(ens0)
+    imcsteps.append(imcsteps0)
+    return replicas, ensembles, imcsteps
 
+
+def read_log(log, pn):
+    """
+    return the whole replica flow for a pn throughout all
+    infinit steps
+    """
+    # what we want:
+    # p0 -> p10 -> p16 -> p20 -> p23 -> p31 -> p34 -> p50
+    # e0 ->  e1 ->  e0 ->  e1 ->  e1 ->  e0 ->  e0 ->  e1
+
+    # get pn, pn id, init rounds and shootings
+    paths, codes, inits, shootings = assign_code(log)
+    replicas, ensembles, imcsteps = step_flow(log, inits)
+
+    # connect replica flow for a pn code between individiual infinit steps
     follow_pn = []
     follow_en = []
     follow_size = []
@@ -113,13 +154,33 @@ def read_log(log, pn):
                 break
         follow_size.append((len(replica), len(rep_codesl)))
 
+    # connect all pns, ens and codes together
     pns = ("+".join(follow_pn[::-1])).split("+")
     ens = ("+".join(follow_en[::-1])).split("+")
+    cds = [paths[int(pn)] for pn in pns]
 
-    paths = list(paths.keys())
-    shootings0 = {pn: sht for pn, sht in zip(paths, shootings)}
+    # here multiple pns may refer to the same path (code).
+    # we select the unique only here
+    pns_uniq = []
+    ens_uniq = []
+    codes0 = []
+    for ens0, pn in zip(ens, pns):
+        code0 = paths[int(pn)]
+        if code0 not in codes0:
+            pns_uniq.append(pn)
+            ens_uniq.append(ens0)
+            codes0.append(code0)
+
+    # connect shooting with pn
+    pathsl = list(paths.keys())
+    shootings0 = {pn: sht for pn, sht in zip(pathsl, shootings)}
     shootings1 = []
     for pn in pns:
         shootings1.append(shootings0[int(pn)])
 
-    return ens, pns, follow_size[::-1], shootings1
+    # connect shooting with pn_unique
+    shootings2 = []
+    for pn in pns_uniq:
+        shootings2.append(shootings0[int(pn)])
+
+    return ens, pns, follow_size[::-1], shootings1, pns_uniq, ens_uniq, shootings2, imcsteps

--- a/inftools/tistools/calc_iflow.py
+++ b/inftools/tistools/calc_iflow.py
@@ -1,0 +1,44 @@
+from typing import Annotated
+import typer
+
+# Disable automatic underscore -> hyphen in CLI names
+# typer.main.get_command_name = lambda name: name
+
+def calc_iflow(
+    plot: Annotated[str, typer.Option("-plot", help="Plot the flow for those paths, string of spaced idxes")]="",
+    log: Annotated[str, typer.Option("-log", help="The .log file to read path numbers")] = "sim.log",
+    ):
+    """
+    Calculates and plots the flow of individual replica across ensembles.
+
+    Returns a flow_map dictionary.
+    """
+    import numpy as np
+    import tomli
+    import matplotlib.pyplot as plt
+
+    from inftools.misc.misc import read_log
+    from inftools.tistools.max_op import COLS
+
+
+    for idx0, rep in enumerate([int(i) for i in plot.split(" ")]):
+    
+        ens, pns, follow_size, shootings = read_log("sim.log", rep)
+        print("ens:", " ".join(ens))
+        print("pns:", " ".join(pns))
+    
+        plt.plot(shootings, [int(i) for i in ens], color=COLS[idx0])
+        plt.scatter(shootings, [int(i) for i in ens], color=COLS[idx0])
+        if idx0 == 0:
+            acc = 50
+            for idx, fs in enumerate(follow_size):
+                plt.plot([acc*idx, acc*(idx+1)], [fs[0]-1]*2, color="k")
+            # acc += fs[1]
+            # acc += 50
+    
+    
+    plt.xlabel("MC Moves")
+    plt.ylabel("Ensemble")
+    plt.ylim([0, None])
+    plt.savefig("iflow.png")
+    plt.show()

--- a/inftools/tistools/calc_iflow.py
+++ b/inftools/tistools/calc_iflow.py
@@ -1,4 +1,5 @@
 from typing import Annotated
+
 import typer
 
 # Disable automatic underscore -> hyphen in CLI names
@@ -13,8 +14,6 @@ def calc_iflow(
 
     Returns a flow_map dictionary.
     """
-    import numpy as np
-    import tomli
     import matplotlib.pyplot as plt
 
     from inftools.misc.misc import read_log
@@ -22,11 +21,11 @@ def calc_iflow(
 
 
     for idx0, rep in enumerate([int(i) for i in plot.split(" ")]):
-    
+
         ens, pns, follow_size, shootings = read_log("sim.log", rep)
         print("ens:", " ".join(ens))
         print("pns:", " ".join(pns))
-    
+
         plt.plot(shootings, [int(i) for i in ens], color=COLS[idx0])
         plt.scatter(shootings, [int(i) for i in ens], color=COLS[idx0])
         if idx0 == 0:
@@ -35,8 +34,8 @@ def calc_iflow(
                 plt.plot([acc*idx, acc*(idx+1)], [fs[0]-1]*2, color="k")
             # acc += fs[1]
             # acc += 50
-    
-    
+
+
     plt.xlabel("MC Moves")
     plt.ylabel("Ensemble")
     plt.ylim([0, None])

--- a/inftools/tistools/calc_iflow.py
+++ b/inftools/tistools/calc_iflow.py
@@ -14,7 +14,11 @@ def calc_iflow(
 
     Returns a flow_map dictionary.
     """
+    import numpy as np
     import matplotlib.pyplot as plt
+
+    # import scienceplots
+    # plt.style.use('science')
 
     from inftools.misc.misc import read_log
     from inftools.tistools.max_op import COLS
@@ -22,18 +26,22 @@ def calc_iflow(
 
     for idx0, rep in enumerate([int(i) for i in plot.split(" ")]):
 
-        ens, pns, follow_size, shootings = read_log("sim.log", rep)
-        print("ens:", " ".join(ens))
-        print("pns:", " ".join(pns))
+        ens, pns, follow_size, shootings, pns_uniq, ens_uniq, shootings2, imcsteps = read_log(log, rep)
+        print("ens:", " ".join(pns_uniq))
+        print("pns:", " ".join(ens_uniq))
 
-        plt.plot(shootings, [int(i) for i in ens], color=COLS[idx0])
-        plt.scatter(shootings, [int(i) for i in ens], color=COLS[idx0])
+        plt.plot(shootings2, [int(i) for i in ens_uniq], color=COLS[idx0%len(COLS)], zorder=10)
+        plt.scatter(shootings2, [int(i) for i in ens_uniq], color=COLS[idx0%len(COLS)], zorder=10, s=15, edgecolor="k")
         if idx0 == 0:
-            acc = 50
-            for idx, fs in enumerate(follow_size):
-                plt.plot([acc*idx, acc*(idx+1)], [fs[0]-1]*2, color="k")
-            # acc += fs[1]
-            # acc += 50
+            accum = np.cumsum([0] + imcsteps)
+            for idx, (istep, fs) in enumerate(zip(imcsteps, follow_size)):
+                plt.plot([accum[idx], accum[idx+1]], [fs[0]]*2, color="k", ls="--")
+                if idx < len(imcsteps)-1:
+                    dfs = follow_size[idx+1][0]-follow_size[idx][0]
+                    plt.plot([accum[idx+1]]*2, [0, follow_size[idx][0] + dfs], color="k", ls="--", alpha=0.1)
+                    if dfs == 0:
+                        continue
+                    plt.plot([accum[idx+1]]*2, [follow_size[idx][0], follow_size[idx][0] + dfs], color="k", ls="--")
 
 
     plt.xlabel("MC Moves")

--- a/inftools/tistools/calc_iflow.py
+++ b/inftools/tistools/calc_iflow.py
@@ -23,7 +23,6 @@ def calc_iflow(
     from inftools.misc.misc import read_log
     from inftools.tistools.max_op import COLS
 
-
     for idx0, rep in enumerate([int(i) for i in plot.split(" ")]):
 
         ens, pns, follow_size, shootings, pns_uniq, ens_uniq, shootings2, imcsteps = read_log(log, rep)


### PR DESCRIPTION
I think it would be interesting to see if the e.g. first reactive replica always resides in the highest ensemble throughout infinit steps.

With this tool, we can investigate this with `inft calc_iflow -plot 1050` where 1050 is the path number,

<img width="640" height="480" alt="iflow" src="https://github.com/user-attachments/assets/a7b13323-747f-4d2e-9f77-d09fdf0f3da8" />

and in this case it does seem like replica exchange matters.

This can actually also display the replica flow for infretis simulations, and yield the same result as `inft calc_flow2` (but don't require infretis.toml, only sim.log"). We should clean this up at some point ...

