### PR TITLE
Omm initial path fixes

### DIFF
--- a/inftools/tistools/initial_paths.py
+++ b/inftools/tistools/initial_paths.py
@@ -31,8 +31,12 @@ def generate_zero_paths(
     config0 = read_toml(toml)
 
     # make a directory we work from
-    tmp_dir = pl.Path("temporary_load/")
-    tmp_dir.mkdir(exist_ok = False)
+    if config0["engine"]["class"] == "ase_external":
+        tmp_dir = pl.Path("worker0")
+        tmp_dir.mkdir(exist_ok = True)
+    else:
+        tmp_dir = pl.Path("worker0")
+        tmp_dir.mkdir(exist_ok = False)
     load_dir = pl.Path(config0["simulation"].get("load_dir", "load"))
     load_dir.mkdir(exist_ok = False)
 
@@ -55,13 +59,15 @@ def generate_zero_paths(
     engine_key = list(state.engines.keys())[0]
     engine = state.engines[engine_key][0]
     engine.exe_dir = str(tmp_dir.resolve())
+    wmdrun = False
     if "dask" in config.keys():
         wmdrun = config["dask"]["wmdrun"][0]
-    else:
+    elif "wmdrun" in config["runner"].keys():
         wmdrun = config["runner"]["wmdrun"][0]
-    engine.set_mdrun(
-        {"wmdrun": wmdrun, "exe_dir": engine.exe_dir}
-    )
+    if wmdrun:
+        engine.set_mdrun(
+            {"wmdrun": wmdrun, "exe_dir": engine.exe_dir}
+        )
     system0.set_pos((os.path.abspath(initial_configuration), 0))
     system0.order = engine.calculate_order(system0)
     engine.rgen = np.random.default_rng()

--- a/inftools/tistools/shoot.py
+++ b/inftools/tistools/shoot.py
@@ -107,7 +107,7 @@ def shoot(
             start_cond = ("R")
     elif order[0] >= intf[0]:
         ens_intf = (intf[0],intf[0],intf[-1])
-        start_cond = ("L")
+        start_cond = ("L","R")
     else:
         exit(f"[ERROR] order value >= interface[-1] ({intf[-1]})!"
         " Not sure what you want to do here.")
@@ -121,7 +121,9 @@ def shoot(
             "rgen": engine.rgen,
             }
     success, out_path, status = shoot(ens_set, path, engine, shooting_point, start_cond)
+    out_path.status = "ACC"
     out_path.path_number = 0
     pstore = PathStorage()
     pstore.keep_traj_fnames = config.get("output",{}).get("keep_traj_fnames",[])
-    pstore.output(0, {"path": out_path, "dir": wdir})
+    pstore.output(0, {"path": out_path, "dir": wdir, "status": "ACC"})
+    return out_path


### PR DESCRIPTION
* `initial_path_from_iretis` now works with `external_ase`, so `cstep = -1` can be used with inf-init
* `shoot()` now allows sampling B->A paths, which caused non-valid paths earlier
* some `wmdrun` fixes if the entry is not present